### PR TITLE
Flushes output when printing device information

### DIFF
--- a/EndPointController/EndPointController.cpp
+++ b/EndPointController/EndPointController.cpp
@@ -226,6 +226,7 @@ HRESULT printDeviceInfo(IMMDevice* pDevice, int index, LPCWSTR outFormat, LPWSTR
 				strID
 			);
 			wprintf_s(_T("\n"));
+			fflush(stdout);
 		}
 
 		pStore->Release();


### PR DESCRIPTION
This allows other programs to capture the output.
Previously, `EndPointController -a > foo.txt` and similar would generate an empty file instead of capturing the output.
